### PR TITLE
Fixes #51 进入nastool主页响应太慢 

### DIFF
--- a/app/helper/indexer_helper.py
+++ b/app/helper/indexer_helper.py
@@ -33,7 +33,6 @@ class IndexerHelper:
             ExceptionUtils.exception_traceback(err)
 
     def get_all_indexers(self):
-        self.init_config()
         return self._indexers
 
     def get_public_indexers(self):
@@ -70,7 +69,6 @@ class IndexerHelper:
                     render=None,
                     language=None,
                     pri=None):
-        self.init_config()
         if not url:
             return None
         _all_indexers = self._indexers + self._private_indexers

--- a/app/helper/indexer_helper.py
+++ b/app/helper/indexer_helper.py
@@ -25,6 +25,7 @@ class IndexerHelper:
         except Exception as err:
             ExceptionUtils.exception_traceback(err)
 
+        self._indexers.clear()
         try:
             for inexer in DbHelper().get_indexer_custom_site():
                 self._indexers.append(json.loads(inexer.INDEXER))


### PR DESCRIPTION
Fixes #51 
_indexers数组只增不减，遍历消耗大量时间和资源，每次添加前清空；
减少频繁调用initConfig造成的io问题（调用索引列表大概会减少300ms的延迟，但是插件增删索引站点时可能要重启生效）

bug复现方式: 在“自定义索引器”中添加站点后，一直刷新索引器界面（或者其他任何有调用索引器的操作）就会无限往_indexers里添加，元素过千时候遍历时间到秒级，会导致web越来越卡