### PR TITLE
添加或者更新站点失败时，弹窗提醒用户

### DIFF
--- a/web/action.py
+++ b/web/action.py
@@ -1119,8 +1119,10 @@ class WebAction:
                                   cookie=cookie,
                                   note=note,
                                   rss_uses=rss_uses)
-
-        return {"code": ret}
+        if ret:
+            return {"code": "200"}
+        else:
+            return {"code": "400", "msg": "更新数据库失败，请重试"}
 
     @staticmethod
     def __get_site(data):

--- a/web/templates/site/site.html
+++ b/web/templates/site/site.html
@@ -661,6 +661,19 @@
     ajax_post("update_site", data, function (ret) {
       $("#add_or_edit_site_btn").attr("disabled", false).text("新增");
       $("#modal-site").modal("hide");
+      if (ret === undefined) {
+        show_fail_modal("！", function () {
+          GlobalModalAbort = true;
+          window_history_refresh();
+        });
+      }
+
+      if (ret.code !== "200") {
+        show_fail_modal(ret.msg, function () {
+          GlobalModalAbort = true;
+          navmenu('site');
+        });
+      }
       //刷新页面
       window_history_refresh();
     });


### PR DESCRIPTION
目前添加或者更新站点失败时，直接刷新页面了，使用的人不知道发生了啥，所以添加了“添加或者更新站点失败时，弹窗提醒用户”这个功能