### PR TITLE
correct cache-control & use webp format for doubanio

### DIFF
--- a/app/media/douban.py
+++ b/app/media/douban.py
@@ -13,7 +13,7 @@ from app.utils.commons import singleton
 from app.utils.types import MediaType
 
 lock = Lock()
-
+prefer_webp = True
 
 @singleton
 class DouBan:
@@ -396,6 +396,7 @@ class DouBan:
 
     @staticmethod
     def __dict_items(infos, media_type=None, poster_filter=False):
+        
         """
         转化为字典
         """
@@ -448,6 +449,10 @@ class DouBan:
                 poster_path = poster_path.replace("s_ratio_poster", "m_ratio_poster")
             elif poster_filter:
                 continue
+            
+            # prefer webp format
+            if prefer_webp:
+                poster_path = poster_path.replace("jpg", "webp")
 
             ret_infos.append({
                 'id': "DB:%s" % rid,

--- a/web/backend/web_utils.py
+++ b/web/backend/web_utils.py
@@ -205,4 +205,6 @@ class WebUtils:
             ret = RequestUtils().get_res(url)
         if ret:
             return ret.content
-        return None
+        
+        # 避免 lru 缓存失败的情况，exception 不会被缓存
+        raise Exception('request failed')

--- a/web/main.py
+++ b/web/main.py
@@ -69,6 +69,7 @@ App.wsgi_app = ProxyFix(App.wsgi_app)
 App.config['JSON_AS_ASCII'] = False
 App.config['JSON_SORT_KEYS'] = False
 App.config['SOCK_SERVER_OPTIONS'] = {'ping_interval': 25}
+App.config['SESSION_REFRESH_EACH_REQUEST'] = False
 App.secret_key = os.urandom(24)
 App.permanent_session_lifetime = datetime.timedelta(days=30)
 

--- a/web/main.py
+++ b/web/main.py
@@ -1763,15 +1763,19 @@ def Img():
     if_none_match = request.headers.get('If-None-Match')
     if if_none_match and if_none_match == etag:
         return make_response('', 304)
+    
     # 获取图片数据
-    response = Response(
-        WebUtils.request_cache(url),
-        mimetype='image/jpeg'
-    )
-    response.headers.set('Cache-Control', 'max-age=604800')
-    response.headers.set('Etag', etag)
-    return response
-
+    try:
+      img = WebUtils.request_cache(url)
+      response = Response(
+          img,
+          mimetype='image/jpeg'
+      )
+      response.headers.set('Cache-Control', 'max-age=604800')
+      response.headers.set('Etag', etag)
+      return response
+    except:
+      return make_response("图片加载失败", 400)
 
 @App.route('/stream-logging')
 @login_required


### PR DESCRIPTION
Due to each request refreshes the cookie, usually browser will refuses to follow cache-control which returned in the response of API: /img to cache assets. This effectively leads to more asset requests are sent to doubanio (since data cached in the LRU can be easily fanned out in this app). Consequently, this results in slow image loading when accessing related pages.

the first commit reduces the requests sent to doubanio from server, image resources are now hitting the browser cache and web experiences is improved, making the LRU cache more efficient.

before:
![1697883492623](https://github.com/hsuyelin/nas-tools/assets/3467408/cc82ed8c-df4a-4abe-8e15-0fc33a25b425)

after:
![1697883424525](https://github.com/hsuyelin/nas-tools/assets/3467408/8b421562-3f6f-4a83-9ad9-274f92355a74)

about config: SESSION_REFRESH_EACH_REQUEST
pls see: https://docs.jinkan.org/docs/flask/config.html
or you can put this in config.yaml

In second commit, I changed the default format for Douban assets to webp, which is smaller and loads faster.

In the third commit, I fixed the issue that LRU might cache incorrect image results, i.e. None.

