### PR TITLE
feat: expose library-resume to api/v1

### DIFF
--- a/web/action.py
+++ b/web/action.py
@@ -240,6 +240,7 @@ class WebAction:
             "get_category_config": self.get_category_config,
             "get_system_processes": self.get_system_processes,
             "run_plugin_method": self.run_plugin_method,
+            "get_library_resume": self.__get_resume,
         }
         # 远程命令响应
         self._commands = {
@@ -2609,6 +2610,15 @@ class WebAction:
                     os.remove(file_path)
 
         return {"code": 1, "msg": "文件不存在"}
+
+    @staticmethod
+    def __get_resume(data):
+        """
+        获得继续观看
+        """
+        num = data.get("num") or 12
+        # 实测，plex 似乎无法按照数目返回，此处手动切片
+        return { "code": 0, "list": MediaServer().get_resume(num)[0:num] }
 
     @staticmethod
     def __start_mediasync(data):

--- a/web/apiv1.py
+++ b/web/apiv1.py
@@ -912,6 +912,17 @@ class LibraryPlayHistory(ClientResource):
         """
         return WebAction().api_action(cmd='get_library_playhistory')
 
+@library.route('/mediaserver/resume')
+class LibraryResume(ClientResource):
+    parser = reqparse.RequestParser()
+    parser.add_argument('num', type=int, help='返回记录数', location='form', required=True)
+
+    @library.doc(parser=parser)
+    def post(self):
+        """
+        查询媒体库继续观看列表
+        """
+        return WebAction().api_action(cmd='get_library_resume', data=self.parser.parse_args())
 
 @library.route('/mediaserver/statistics')
 class LibraryStatistics(ClientResource):


### PR DESCRIPTION
WHAT's CHANGED:

A new API has been registered in the api/v1 for querying the "Continue Watching" list of the current media library. Additionally, it has been tested, and despite exposing the 'num' parameter, services like Plex are unable to return results as needed. Therefore, I manually performed list slicing within the function.