### PR TITLE
feat(api/downloader): add parameters in api:/now

### DIFF
--- a/app/downloader/downloader.py
+++ b/app/downloader/downloader.py
@@ -628,14 +628,14 @@ class Downloader:
             ExceptionUtils.exception_traceback(err)
             return None
 
-    def get_downloading_progress(self, downloader_id=None, ids=None):
+    def get_downloading_progress(self, downloader_id=None, ids=None, force_list = False):
         """
         查询正在下载中的进度信息
         """
         if not downloader_id:
             downloader_id = self.default_downloader_id
         downloader_conf = self.get_downloader_conf(downloader_id)
-        only_nastool = downloader_conf.get("only_nastool")
+        only_nastool = downloader_conf.get("only_nastool") if not force_list else False
         _client = self.__get_client(downloader_id)
         if not _client:
             return []

--- a/web/action.py
+++ b/web/action.py
@@ -3761,13 +3761,16 @@ class WebAction:
         return {"code": 0, "result": [rec.as_dict() for rec in Rss().get_rss_history(rtype=mtype)]}
 
     @staticmethod
-    def get_downloading():
+    def get_downloading(data = {}):
         """
         查询正在下载的任务
         """
+        dl_id = data.get("id")
+        force_list = data.get("force_list")
         MediaHander = Media()
         DownloaderHandler = Downloader()
-        torrents = DownloaderHandler.get_downloading_progress()
+        torrents = DownloaderHandler.get_downloading_progress(downloader_id=dl_id, force_list=bool(force_list))
+        
         for torrent in torrents:
             # 先查询下载记录，没有再识别
             name = torrent.get("name")

--- a/web/action.py
+++ b/web/action.py
@@ -13,6 +13,7 @@ from math import floor
 from pathlib import Path
 from urllib.parse import unquote
 import ast
+import copy
 
 import cn2an
 from flask_login import logout_user, current_user
@@ -5027,8 +5028,29 @@ class WebAction:
         """
         获取下载器
         """
+        def add_is_default(dl_conf, defualt_id):
+            dl_conf["is_default"] = str(dl_conf["id"]) == defualt_id
+            return dl_conf
+        
         did = data.get("did")
-        return {"code": 0, "detail": Downloader().get_downloader_conf(did=did)}
+        downloader = Downloader()
+        resp = downloader.get_downloader_conf(did=did)
+        default_dl_id = downloader.default_downloader_id
+
+        if did:
+            """
+              单个下载器 conf
+            """
+            return {"code": 0, "detail": add_is_default(copy.deepcopy(resp), default_dl_id) if resp else None}
+        else:
+            """
+              所有下载器 conf
+            """
+            confs = copy.deepcopy(resp)
+            for key in confs:
+                add_is_default(confs[key], default_dl_id)
+
+            return {"code": 0, "detail": confs}
 
     @staticmethod
     def __test_downloader(data):

--- a/web/apiv1.py
+++ b/web/apiv1.py
@@ -590,12 +590,16 @@ class DownloadHistory(ClientResource):
 
 @download.route('/now')
 class DownloadNow(ClientResource):
-    @staticmethod
-    def post():
+    parser = reqparse.RequestParser()
+    parser.add_argument('id', type=int, help='下载器 id', location='form', required=False)
+    parser.add_argument('force_list', type=bool, help='强制列出所有下载任务', location='form', required=False)
+
+    @download.doc(parser=parser)
+    def post(self):
         """
         查询正在下载的任务
         """
-        return WebAction().api_action(cmd='get_downloading')
+        return WebAction().api_action(cmd='get_downloading', data=self.parser.parse_args())
 
 
 @download.route('/config/info')


### PR DESCRIPTION
WHAT's changed: 

The /now API has following two changes:

1. An additional parameter has been added to explicitly specify the downloader ID for listing its download tasks.
2. Another parameter has been included to control whether to forcefully list all tasks within the downloader.

Both of parameters are optional, and the default behavior aligns with the current API behavior.

Furthermore, I've added the 'is_default' field in the response of the '/download/client/list' to indicate whether it is the default downloader.