### PR TITLE
使用Cloudflare Worker搭建Telegram Bot Api 代理

### DIFF
--- a/config.py
+++ b/config.py
@@ -235,3 +235,11 @@ class Config(object):
         if category:
             return os.path.join(Config().get_config_path(), f"{category}.yaml")
         return None
+
+    def get_telegram_domain(self):
+        telegram_domain = (self.get_config('laboratory') or {}).get("telegram_domain", "https://api.telegram.org")
+        if telegram_domain and telegram_domain.startswith("http"):
+            telegram_domain = "https://api.telegram.org"
+        if telegram_domain and telegram_domain.endswith("/"):
+            telegram_domain = telegram_domain[:-1]
+        return telegram_domain

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -217,3 +217,5 @@ laboratory:
   show_more_sites: true
   # 【入库通知精简】：开启后会简化入库推送通知
   simplify_library_notification: false
+  # 《使用Cloudflare Worker搭建Telegram Bot Api 代理》https://www.yuque.com/u21363723/nt6hcz/whq99ankmn87arcq?singleDoc
+  telegram_domain:

--- a/web/templates/setting/basic.html
+++ b/web/templates/setting/basic.html
@@ -713,6 +713,15 @@
           </div>
           <div class="card-body">
             <div class="row">
+              <div class="col-12 col-xl-12">
+                    <div class="mb-3">
+                      <label class="form-label">Telegram Bot Api 代理<span class="form-help"
+                                                                            title="使用Cloudflare Worker搭建Telegram Bot Api 代理, 配置教程：https://www.yuque.com/u21363723/nt6hcz/whq99ankmn87arcq?singleDoc"
+                                                                            data-bs-toggle="tooltip">?</span></label>
+                      <input type="text" value="{% if Config.laboratory %}{{ Config.laboratory.telegram_domain or '' }}{% endif %}" class="form-control"
+                             id="laboratory.telegram_domain" placeholder="https://api.telegram.org" autocomplete="off">
+                </div>
+              </div>
               <div class="col-12 col-xl-3">
                 <div class="mb-3">
                   <label class="form-check form-switch">


### PR DESCRIPTION
新增功能
使用Cloudflare Worker搭建Telegram Bot Api 代理
具体搭建步骤：https://www.yuque.com/u21363723/nt6hcz/whq99ankmn87arcq?singleDoc
并支持在后台 - 设置 - 基础设置 - 实验室 - Telegram Bot Api 代理 填写已经搭建好的域名
![image](https://github.com/hsuyelin/nas-tools/assets/19778582/3e48a360-bd9e-4ed6-bc8d-b041e05d90a7)
