### PR TITLE
使用Cloudflare Worker搭建Telegram Bot Api 代理

### DIFF
--- a/config.py
+++ b/config.py
@@ -64,7 +64,8 @@ KEYWORD_SEARCH_WEIGHT_3 = [10, 2]
 KEYWORD_STR_SIMILARITY_THRESHOLD = 0.2
 KEYWORD_DIFF_SCORE_THRESHOLD = 30
 KEYWORD_BLACKLIST = ['中字', '韩语', '双字', '中英', '日语', '双语', '国粤', 'HD', 'BD', '中日', '粤语', '完全版',
-                     '法语', '西班牙语', 'HRHDTVAC3264', '未删减版', '未删减', '国语', '字幕组', '人人影视', 'www66ystv',
+                     '法语', '西班牙语', 'HRHDTVAC3264', '未删减版', '未删减', '国语', '字幕组', '人人影视',
+                     'www66ystv',
                      '人人影视制作', '英语', 'www6vhaotv', '无删减版', '完成版', '德意']
 
 # WebDriver路径
@@ -235,3 +236,10 @@ class Config(object):
         if category:
             return os.path.join(Config().get_config_path(), f"{category}.yaml")
         return None
+
+    def get_telegram_domain(self):
+        telegram_domain = (self.get_config('laboratory') or {}).get("telegram_domain", "https://api.telegram.org")
+        if telegram_domain and telegram_domain.endswith("/"):
+            telegram_domain = telegram_domain[:-1]
+        print(f"【Config】设置 Telegram Bot Api 为 {telegram_domain}")
+        return telegram_domain

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -217,3 +217,5 @@ laboratory:
   show_more_sites: true
   # 【入库通知精简】：开启后会简化入库推送通知
   simplify_library_notification: false
+  # 《使用Cloudflare Worker搭建Telegram Bot Api 代理》https://www.yuque.com/u21363723/nt6hcz/whq99ankmn87arcq?singleDoc
+  telegram_domain:

--- a/web/templates/setting/basic.html
+++ b/web/templates/setting/basic.html
@@ -713,6 +713,15 @@
           </div>
           <div class="card-body">
             <div class="row">
+              <div class="col-12 col-xl-12">
+                    <div class="mb-3">
+                      <label class="form-label">Telegram Bot Api 代理<span class="form-help"
+                                                                            title="使用Cloudflare Worker搭建Telegram Bot Api 代理, 配置教程：https://www.yuque.com/u21363723/nt6hcz/whq99ankmn87arcq?singleDoc"
+                                                                            data-bs-toggle="tooltip">?</span></label>
+                      <input type="text" value="{% if Config.laboratory %}{{ Config.laboratory.telegram_domain or '' }}{% endif %}" class="form-control"
+                             id="laboratory.telegram_domain" placeholder="https://api.telegram.org" autocomplete="off">
+                </div>
+              </div>
               <div class="col-12 col-xl-3">
                 <div class="mb-3">
                   <label class="form-check form-switch">


### PR DESCRIPTION
具体搭建步骤：https://www.yuque.com/u21363723/nt6hcz/whq99ankmn87arcq?singleDoc 
并支持在后台 - 设置 - 基础设置 - 实验室 - Telegram Bot Api 代理 填写已经搭建好的域名
![image](https://github.com/hsuyelin/nas-tools/assets/19778582/8273b836-b0a8-45a4-bf1a-e993017e76f6)
发送消息测试
![image](https://github.com/hsuyelin/nas-tools/assets/19778582/53f6a4b4-c03f-4dfd-8133-b7578ca00858)
