### PR TITLE
支持多级分类目录和按照评分规则分类目录

### DIFF
--- a/app/media/category.py
+++ b/app/media/category.py
@@ -165,6 +165,8 @@ class Category:
                 return False, ""
             elif key == "production_countries":
                 info_values = [str(val.get("iso_3166_1")).upper() for val in info_value]
+            elif key == "vote_average":
+                info_values = [str(int(info_value)).upper()]
             else:
                 if isinstance(info_value, list):
                     info_values = [str(val).upper() for val in info_value]

--- a/config/default-category.yaml
+++ b/config/default-category.yaml
@@ -9,7 +9,7 @@ movie:
     genre_ids: '16'
   华语电影:
     # 分类依据，可以是：original_language 语种、production_countries(电影)/origin_country(电视剧) 国家或地区、genre_ids 内容类型等，只要TMDB API返回的字段中有就行
-    # 配置多项条件时，需要同时满足；不需要的匹配项可以删掉或者配置为空
+    # 配置多项条件时，需要同时满足；不需要的匹配项需要删掉，不可留空
     # 匹配值对应用,号分隔，这里是匹配语种
     original_language: 'zh,cn,bo,za'
   # 未配置任何过滤条件时，则按先后顺序不符合上面分类的都会在这个分类下，建议配置在最末尾


### PR DESCRIPTION
支持多级分类，例如:
```yaml
movie:
  华语电影:
    original_language: 'zh,cn,bo,za'
    高分电影:
      vote_average: '7,8,9'
    一般电影:
      vote_average: '4,5,6'
    垃圾电影:
  动画电影:
    genre_ids: '16'
  外语电影:
```
注意，新的逻辑会将留空的规则视为不匹配，这个可能会破坏已有的配置。

转移效果如下:
```
正在转移文件：Breakfast at Tiffany's (1961) - 576p.mkv
=> /media/videos/已刮削/movie/外语电影/高分电影/1960s/蒂凡尼的早餐 (1961)/Breakfast at Tiffany's (1961) - 576p.mkv
正在转移文件：Yojinbo Jitsugetsusho (1989) - 576p.mkv
=> /media/videos/已刮削/movie/垃圾电影/1980s/Yojinbo Jitsugetsusho (1989)/Yojinbo Jitsugetsusho (1989) - 576p.mkv
```