### PR TITLE
string_utils: 不需要将半角切换到全角

### DIFF
--- a/app/utils/string_utils.py
+++ b/app/utils/string_utils.py
@@ -318,8 +318,6 @@ class StringUtils:
         filename_prefer_barre = media.get("filename_prefer_barre", False) or False
         if filename_prefer_barre:
             cleaned_name = cleaned_name.replace(":", " - ").replace("：", " - ")
-        else:
-            cleaned_name = cleaned_name.replace(":", "：")
         return cleaned_name
 
     @staticmethod


### PR DESCRIPTION
电影名称中的半角: 一般出现在英文标题中，全角：出现在中文标题中。
将英文名称中的半角转换成全角符号没有意义。