### PR TITLE
Fix PikPak download directory lost.

### DIFF
--- a/app/downloader/client/pikpak.py
+++ b/app/downloader/client/pikpak.py
@@ -106,7 +106,7 @@ class PikPak(_IDownloadClient):
 
     def add_torrent(self, content, download_dir=None, **kwargs):
         try:
-            task = asyncio.run(self._client.offline_download(content))
+            task = asyncio.run(self._client.offline_download(content, download_dir))
             taskId = task.get('task', {}).get('id')
             return taskId is not None and bool(taskId)
         except Exception as e:

--- a/web/templates/setting/downloader.html
+++ b/web/templates/setting/downloader.html
@@ -571,7 +571,7 @@
     </div>
     <div class="row">
       <div class="col-12 col-lg mb-1">
-        <input type="text" value="" id="save_path_{DIRDIV_LEVEL}" class="form-control" placeholder="下载保存目录" autocomplete="off">
+        <input type="text" value="" id="save_path_{DIRDIV_LEVEL}" class="form-control" placeholder="下载保存目录或ID" autocomplete="off">
       </div>
       <div class="col-12 col-lg mb-1">
         <input type="text" value="" id="container_path_{DIRDIV_LEVEL}" class="form-control" placeholder="NAStool访问目录" autocomplete="off">


### PR DESCRIPTION
 PikPak downloader requires a folder ID to correctly set the download directory. This pull request seeks to address this issue.