### PR TITLE
fix: indexer 处理没有tmdb没有年份项目时出错

### DIFF
--- a/app/indexer/client/_base.py
+++ b/app/indexer/client/_base.py
@@ -122,7 +122,7 @@ class _IIndexClient(metaclass=ABCMeta):
                                 match_media.original_title in torrent_name or \
                                 match_media.org_string in description or \
                                 match_media.original_title in description
-                    year_match = match_media.year in torrent_name or \
+                    year_match = not match_media.year or match_media.year in torrent_name or \
                                  match_media.year in description
                 if (imdbid_match or name_match) and year_match and self.recognize_enhance_enable:
                     meta_info = MetaInfo(title=torrent_name,


### PR DESCRIPTION
![image](https://github.com/hsuyelin/nas-tools/assets/7975549/4b18471a-2850-41d3-996f-02f497bcd03e)
tmdb项目没有年份时直接忽略，修复报错导致搜不到结果 且前后数据不匹配