### PR TITLE
filetransfer: 当没有年份的时候年代设置为0

### DIFF
--- a/app/filetransfer.py
+++ b/app/filetransfer.py
@@ -1244,7 +1244,10 @@ class FileTransfer:
         episode_title = self.media.get_episode_title(media)
         # 英文标题
         en_title = self.media.get_tmdb_en_title(media)
-        decade = (int(media.year) // 10) * 10
+        try:
+            decade = (int(media.year) // 10) * 10
+        except:
+            decade = 0
         media_format_dict = {
             "title": StringUtils.clear_file_name(media.title),
             "en_title": StringUtils.clear_file_name(en_title),


### PR DESCRIPTION
有些电影的数据不全，甚至没有发行年份，例如 tmdb id 1079858。这种情况下
设置年代为0.

注意: 这种情况下，短年代格式会显示 0s, 长年代格式会显示为 0-9s.