### PR TITLE
fix: torrent path with '/'

### DIFF
--- a/app/utils/torrent.py
+++ b/app/utils/torrent.py
@@ -207,7 +207,7 @@ class Torrent:
             file_name = unquote(url.split("/")[-1])
         else:
             file_name = str(datetime.datetime.now())
-        return file_name
+        return file_name.replace('/', '')
 
     @staticmethod
     def get_intersection_episodes(target, source, title):


### PR DESCRIPTION
<img width="596" alt="image" src="https://github.com/hsuyelin/nas-tools/assets/28153001/e2b28e02-f8e9-4428-914f-80a265a755e3">

有的种子文件名会带有 '/'，此 PR 修复了这个问题