### PR TITLE
optim: title matcher when anitopy failed

### DIFF
--- a/app/media/meta/metaanime.py
+++ b/app/media/meta/metaanime.py
@@ -14,7 +14,7 @@ class MetaAnime(MetaBase):
     """
     识别动漫
     """
-    _anime_no_words = ['CHS&CHT', 'MP4', 'GB MP4', 'WEB-DL']
+    _anime_no_words = ['CHS&CHT', 'MP4', 'GB MP4', 'WEB-DL', 'AT-X', 'ADN']
     _name_nostring_re = r"S\d{2}\s*-\s*S\d{2}|S\d{2}|\s+S\d{1,2}|EP?\d{2,4}\s*-\s*EP?\d{2,4}|EP?\d{2,4}|\s+EP?\d{1,4}"
 
     def __init__(self,
@@ -51,13 +51,12 @@ class MetaAnime(MetaBase):
                 if name and name.find("/") != -1:
                     name = name.split("/")[-1].strip()
                 if not name or name in self._anime_no_words or (len(name) < 5 and not StringUtils.is_chinese(name)):
-                    anitopy_info = anitopy.parse("[ANIME]" + title)
-                    if anitopy_info:
-                        name = anitopy_info.get("anime_title")
-                if not name or name in self._anime_no_words or (len(name) < 5 and not StringUtils.is_chinese(name)):
-                    name_match = re.search(r'\[(.+?)]', title)
-                    if name_match and name_match.group(1):
-                        name = name_match.group(1).strip()
+                    # 普遍上第一个非字幕组的 `[]` 中内容为标题
+                    name_match = re.findall(r'\[(.+?)]', title)
+                    for item in name_match:
+                        if not ReleaseGroupsMatcher().match(title=f'[{item}]'):
+                            name = item
+                            break
                 # 拆份中英文名称
                 if name:
                     lastword_type = ""

--- a/app/media/meta/metaanime.py
+++ b/app/media/meta/metaanime.py
@@ -14,7 +14,7 @@ class MetaAnime(MetaBase):
     """
     识别动漫
     """
-    _anime_no_words = ['CHS&CHT', 'MP4', 'GB MP4', 'WEB-DL', 'AT-X', 'ADN']
+    _anime_no_words = ['CHS&CHT', 'MP4', 'GB MP4', 'WEB-DL', 'AT-X', 'ADN', 'HDRip']
     _name_nostring_re = r"S\d{2}\s*-\s*S\d{2}|S\d{2}|\s+S\d{1,2}|EP?\d{2,4}\s*-\s*EP?\d{2,4}|EP?\d{2,4}|\s+EP?\d{1,4}"
 
     def __init__(self,
@@ -189,8 +189,9 @@ class MetaAnime(MetaBase):
         """
         if not title:
             return title
-        # 所有【】换成[]
+        # 符号替换
         title = title.replace("【", "[").replace("】", "]").strip()
+        title = title.replace("／", "/")
         # 截掉xx番剧漫
         match = re.search(r"新番|月?番|[日美国][漫剧]", title)
         if match and match.span()[1] < len(title) - 1:


### PR DESCRIPTION
现有逻辑在 `anitopy` 匹配失败后默认会使用第一个方框内的名字作为番剧标题，但更常见的命名方式中，第一个框内为字幕组名，此 PR 修复了这个问题。

举例：

当标题为: `[Billion Meta Lab][憧憬成为魔法少女][01][1080p][AT-X][简体内嵌]` 时，现有逻辑最后会 fallback 到 `Billion Meta Lab` 上，而在此 PR 中，若自定义了番剧组 `Billion Meta Lab`，则会使用真实标题。