### PR TITLE
Update sync.py，不同步包含'.!qB'的文件

### DIFF
--- a/app/sync.py
+++ b/app/sync.py
@@ -235,7 +235,10 @@ class Sync(object):
 
                 # 不做识别重命名
                 if not rename:
-                    self.__link(event_path, mon_path, target_path, sync_mode)
+                    if '.!qB' in event_path:
+                        log.info(f"【Sync】{event_path} 还未下载完毕，不进行同步")
+                    else:
+                        self.__link(event_path, mon_path, target_path, sync_mode)
                 # 识别转移
                 else:
                     # 不是媒体文件不处理
@@ -390,7 +393,10 @@ class Sync(object):
             # 不做识别重命名
             if not rename:
                 for link_file in PathUtils.get_dir_files(mon_path):
-                    self.__link(link_file, mon_path, target_path, sync_mode)
+                    if '.!qB' in link_file:
+                        log.info(f"【Sync】{link_file} 还未下载完毕，不进行同步")
+                    else:
+                        self.__link(link_file, mon_path, target_path, sync_mode)
             else:
                 for path in PathUtils.get_dir_level1_medias(mon_path, RMT_MEDIAEXT):
                     if PathUtils.is_invalid_path(path):


### PR DESCRIPTION
自己下载的小姐姐资源nt是无法刮削的，同时为了不影响做种，所以都是硬链接到其他地方再用其他工具刮削入库。所以自己的小姐姐资源都是在nt中关闭了自动同步（自动同步设置了自动刮削，用于正常的影视资源）。

因为每次下载小姐姐资源的时候都是下一堆的，不能等所有的都下完了再统一同步刮削（等不及）。但是提前点同步后会把所有文件都同步（包括还没下完后缀带.!qB的文件），后续比较麻烦，故改了一下同步的逻辑，当文件包含'.!qB'时不进行同步。

不知道有没有和我有同样困扰的兄弟啊~有的话可以合并一下PR