### PR TITLE
修复：更换接口域名

### DIFF
--- a/app/plugins/modules/iyuu/iyuu_helper.py
+++ b/app/plugins/modules/iyuu/iyuu_helper.py
@@ -9,7 +9,7 @@ from app.utils.commons import singleton
 @singleton
 class IyuuHelper(object):
     _version = "2.0.0"
-    _api_base = "https://api.iyuu.cn/%s"
+    _api_base = "http://api.bolahg.cn/%s"
     _sites = {}
     _token = None
 


### PR DESCRIPTION
同步iyuu最新仓库的api地址 [gitee](https://gitee.com/ledc/iyuuplus/commit/04aef85b667bcc2f22975dd4c5c0e09e5bb2015d)
![IMG_20240213_094548_248](https://github.com/hsuyelin/nas-tools/assets/39831773/4732c117-9d5c-4093-86af-b81bd1f27a68)
