### PR TITLE
feat(brushtask): 支持当前站点任务数限制

### DIFF
--- a/app/brushtask.py
+++ b/app/brushtask.py
@@ -203,7 +203,7 @@ class BrushTask(object):
                                            dlcount=rss_rule.get("dlcount"),
                                            current_site_count=rss_rule.get("current_site_count"),
                                            current_site_dlcount=rss_rule.get("current_site_dlcount"),
-                                           site_name=site_name):
+                                           site_info=site_info):
             return
 
         rss_result = self.rsshelper.parse_rssxml(url=rss_url, proxy=site_proxy)
@@ -266,7 +266,7 @@ class BrushTask(object):
                                                    torrent_size=size,
                                                    current_site_count=current_site_count,
                                                    current_site_dlcount=current_site_dlcount,
-                                                   site_name=site_name):
+                                                   site_info=site_info):
                     continue
                 # 检查是否已处理过
                 if self.is_torrent_handled(enclosure=enclosure):
@@ -291,7 +291,7 @@ class BrushTask(object):
                                                        dlcount=max_dlcount,
                                                        current_site_count=current_site_count,
                                                        current_site_dlcount=current_site_dlcount,
-                                                       site_name=site_name):
+                                                       site_info=site_info):
                         break
             except Exception as err:
                 ExceptionUtils.exception_traceback(err)
@@ -544,7 +544,7 @@ class BrushTask(object):
             except Exception as e:
                 ExceptionUtils.exception_traceback(e)
 
-    def __is_allow_new_torrent(self, taskinfo, dlcount, current_site_dlcount, current_site_count, site_name, torrent_size=None):
+    def __is_allow_new_torrent(self, taskinfo, dlcount, current_site_dlcount, current_site_count, site_info, torrent_size=None):
         """
         检查是否还能添加新的下载
         """
@@ -595,9 +595,12 @@ class BrushTask(object):
                 return False
 
         # 检查是否添加标签
-        label = taskinfo.get("label").split(',') if taskinfo.get("label") else None
-        if label is None:
+        label = list(set((taskinfo.get("label").split(',') if taskinfo.get("label") else []) +
+                 (site_info.get("tags").split(',') if site_info.get("tags") else [])))
+        if label is None or len(label) <= 0:
             return True
+
+        site_name = site_info.get("name")
 
         # 检查当前站点正在下载的任务数量
         if current_site_dlcount:

--- a/app/brushtask.py
+++ b/app/brushtask.py
@@ -200,7 +200,10 @@ class BrushTask(object):
         log.info("【Brush】开始站点 %s 的刷流任务：%s..." % (site_name, task_name))
         # 检查是否达到保种体积
         if not self.__is_allow_new_torrent(taskinfo=taskinfo,
-                                           dlcount=rss_rule.get("dlcount")):
+                                           dlcount=rss_rule.get("dlcount"),
+                                           current_site_count=rss_rule.get("current_site_count"),
+                                           current_site_dlcount=rss_rule.get("current_site_dlcount"),
+                                           site_name=site_name):
             return
 
         rss_result = self.rsshelper.parse_rssxml(url=rss_url, proxy=site_proxy)
@@ -221,6 +224,11 @@ class BrushTask(object):
         if max_dlcount:
             downloading_count = self.__get_downloading_count(downloader_id) or 0
             new_torrent_count = int(max_dlcount) - int(downloading_count)
+
+        # 当前站点任务总数
+        current_site_count = rss_rule.get("current_site_count")
+        # 当前站点下载任务数
+        current_site_dlcount = rss_rule.get("current_site_dlcount")
 
         for res in rss_result:
             try:
@@ -255,7 +263,10 @@ class BrushTask(object):
                 # 检查能否添加当前种子，判断是否超过保种体积大小
                 if not self.__is_allow_new_torrent(taskinfo=taskinfo,
                                                    dlcount=max_dlcount,
-                                                   torrent_size=size):
+                                                   torrent_size=size,
+                                                   current_site_count=current_site_count,
+                                                   current_site_dlcount=current_site_dlcount,
+                                                   site_name=site_name):
                     continue
                 # 检查是否已处理过
                 if self.is_torrent_handled(enclosure=enclosure):
@@ -277,7 +288,10 @@ class BrushTask(object):
 
                     # 再判断一次
                     if not self.__is_allow_new_torrent(taskinfo=taskinfo,
-                                                       dlcount=max_dlcount):
+                                                       dlcount=max_dlcount,
+                                                       current_site_count=current_site_count,
+                                                       current_site_dlcount=current_site_dlcount,
+                                                       site_name=site_name):
                         break
             except Exception as err:
                 ExceptionUtils.exception_traceback(err)
@@ -530,7 +544,7 @@ class BrushTask(object):
             except Exception as e:
                 ExceptionUtils.exception_traceback(e)
 
-    def __is_allow_new_torrent(self, taskinfo, dlcount, torrent_size=None):
+    def __is_allow_new_torrent(self, taskinfo, dlcount, current_site_dlcount, current_site_count, site_name, torrent_size=None):
         """
         检查是否还能添加新的下载
         """
@@ -571,21 +585,56 @@ class BrushTask(object):
 
         # 检查正在下载的任务数
         if dlcount:
-            downloading_count = self.__get_downloading_count(downloader_id)
-            if downloading_count is None:
+            downloading_total_count = self.__get_downloading_count(downloader_id)
+            if downloading_total_count is None:
                 log.error("【Brush】任务 %s 下载器 %s 无法连接" % (task_name, downloader_name))
                 return False
-            if int(downloading_count) >= int(dlcount):
+            if int(downloading_total_count) >= int(dlcount):
                 log.warn("【Brush】下载器 %s 正在下载任务数：%s，超过设定上限，暂不添加下载" % (
-                    downloader_name, downloading_count))
+                    downloader_name, downloading_total_count))
                 return False
+
+        # 检查是否添加标签
+        label = taskinfo.get("label").split(',') if taskinfo.get("label") else None
+        if label is None:
+            return True
+
+        # 检查当前站点正在下载的任务数量
+        if current_site_dlcount:
+            current_site_count_downloading = self.__get_downloading_count(downloader_id, tag=label)
+            if current_site_count_downloading is None:
+                log.error("【Brush】任务 %s 下载器 %s 无法连接" % (task_name, downloader_name))
+                return False
+            if int(current_site_count_downloading) >= int(current_site_count):
+                log.warn("【Brush】站点 %s 正在下载任务数：%s，超过设定上限，暂不添加下载" % (
+                    site_name, current_site_count_downloading))
+                return False
+
+        # 检查当前站点任务数量
+        if current_site_count:
+            current_site_count_total = self.__get_task_count(downloader_id, tag=label)
+            if current_site_count_total is None:
+                log.error("【Brush】任务 %s 下载器 %s 无法连接" % (task_name, downloader_name))
+                return False
+            if int(current_site_count_total) >= int(current_site_count):
+                log.warn("【Brush】站点 %s 任务总数：%s，超过设定上限，暂不添加下载" % (
+                    site_name, current_site_count_total))
+                return False
+
         return True
 
-    def __get_downloading_count(self, downloader_id):
+    def __get_downloading_count(self, downloader_id, tag=None):
         """
-        查询当前正在下载的任务数
+        查询当前正在下载的任务数，支持限定 tag
         """
-        torrents = self.downloader.get_downloading_torrents(downloader_id=downloader_id) or []
+        torrents = self.downloader.get_downloading_torrents(downloader_id=downloader_id, tag=tag) or []
+        return len(torrents)
+
+    def __get_task_count(self, downloader_id, tag):
+        """
+        查询当前任务总数，限定 tag
+        """
+        torrents = self.downloader.get_torrents(downloader_id=downloader_id, tag=tag) or []
         return len(torrents)
 
     def __download_torrent(self,

--- a/web/action.py
+++ b/web/action.py
@@ -1967,6 +1967,8 @@ class WebAction:
         brushtask_include = data.get("brushtask_include")
         brushtask_exclude = data.get("brushtask_exclude")
         brushtask_dlcount = data.get("brushtask_dlcount")
+        brushtask_current_site_count = data.get("brushtask_current_site_count")
+        brushtask_current_site_dlcount = data.get("dl")
         brushtask_peercount = data.get("brushtask_peercount")
         brushtask_seedtime = data.get("brushtask_seedtime")
         brushtask_seedratio = data.get("brushtask_seedratio")
@@ -1985,6 +1987,8 @@ class WebAction:
             "include": brushtask_include,
             "exclude": brushtask_exclude,
             "dlcount": brushtask_dlcount,
+            "current_site_count": brushtask_current_site_count,
+            "current_site_dlcount": brushtask_current_site_dlcount,
             "peercount": brushtask_peercount,
             "pubdate": brushtask_pubdate,
             "upspeed": brushtask_upspeed,

--- a/web/apiv1.py
+++ b/web/apiv1.py
@@ -1683,6 +1683,8 @@ class BrushTaskUpdate(ClientResource):
     parser.add_argument('brushtask_include', type=str, help='包含', location='form')
     parser.add_argument('brushtask_exclude', type=str, help='排除', location='form')
     parser.add_argument('brushtask_dlcount', type=int, help='同时下载任务数', location='form')
+    parser.add_argument('brushtask_current_site_count', type=int, help='当前站点任务总数', location='form')
+    parser.add_argument('brushtask_current_site_dlcount', type=int, help='当前站点下载任务数', location='form')
     parser.add_argument('brushtask_peercount', type=int, help='做种人数限制', location='form')
     parser.add_argument('brushtask_seedtime', type=float, help='做种时间(小时)', location='form')
     parser.add_argument('brushtask_seedratio', type=float, help='分享率', location='form')

--- a/web/templates/site/brushtask.html
+++ b/web/templates/site/brushtask.html
@@ -448,6 +448,22 @@
                     </div>
                     <div class="col-lg-4">
                         <div class="mb-3">
+                            <label class="form-label">当前站点下载任务数 <span class="form-help"
+                                                                           title="当前站点下载任务数超过此值时不再添加下载，为站点或刷流任务添加标签后生效"
+                                                                           data-bs-toggle="tooltip">?</span></label>
+                            <input type="text" id="brushtask_current_site_dlcount" class="form-control" placeholder="5">
+                        </div>
+                    </div>
+                    <div class="col-lg-4">
+                        <div class="mb-3">
+                            <label class="form-label">当前站点任务总数 <span class="form-help"
+                                                                           title="当前站点任务总数超过此值时不再添加下载，为站点或刷流任务添加标签后生效"
+                                                                           data-bs-toggle="tooltip">?</span></label>
+                            <input type="text" id="brushtask_current_site_count" class="form-control" placeholder="10">
+                        </div>
+                    </div>
+                    <div class="col-lg-4">
+                        <div class="mb-3">
                             <label class="form-label">包含 <span class="form-help"
                                                                  title="种子名称或副标题中包括对应关键字或者匹配正则式时才会下载"
                                                                  data-bs-toggle="tooltip">?</span></label>
@@ -819,6 +835,8 @@
           $("#brushtask_sendmessage").prop("checked", false);
         }
         $("#brushtask_dlcount").val(ret.task.rss_rule.dlcount)
+        $("#brushtask_current_site_count").val(ret.task.rss_rule.current_site_count)
+        $("#brushtask_current_site_dlcount").val(ret.task.rss_rule.current_site_dlcount)
         $("#brushtask_peercount").val(ret.task.rss_rule.peercount)
         $("#brushtask_include").val(ret.task.rss_rule.include);
         $("#brushtask_exclude").val(ret.task.rss_rule.exclude);
@@ -1025,6 +1043,22 @@
     } else {
       $("#brushtask_dlcount").removeClass("is-invalid");
     }
+    //当前站点任务总数
+    let brushtask_current_site_count = $("#brushtask_current_site_count").val();
+    if (brushtask_current_site_count && isNaN(brushtask_current_site_count)) {
+      $("#brushtask_current_site_count").addClass("is-invalid");
+      return;
+    } else {
+      $("#brushtask_current_site_count").removeClass("is-invalid");
+    }
+    //当前站点任务下载数
+    let brushtask_current_site_dlcount = $("#brushtask_current_site_dlcount").val();
+    if (brushtask_current_site_dlcount && isNaN(brushtask_current_site_dlcount)) {
+      $("#brushtask_current_site_dlcount").addClass("is-invalid");
+      return;
+    } else {
+      $("#brushtask_current_site_dlcount").removeClass("is-invalid");
+    }
     //上传限速
     let brushtask_upspeed = $("#brushtask_upspeed").val();
     if (brushtask_upspeed && isNaN(brushtask_upspeed)) {
@@ -1174,6 +1208,8 @@
       brushtask_include: brushtask_include,
       brushtask_exclude: brushtask_exclude,
       brushtask_dlcount: brushtask_dlcount,
+      brushtask_current_site_count: brushtask_current_site_count,
+      brushtask_current_site_dlcount: brushtask_current_site_dlcount,
       brushtask_peercount: brushtask_peercount_do + "#" + brushtask_peercount,
       brushtask_seedtime: brushtask_seedtime_do + "#" + brushtask_seedtime,
       brushtask_seedratio: brushtask_seedratio_do + "#" + brushtask_seedratio,


### PR DESCRIPTION
+ 新增：刷流任务 支持当前站点任务总数限制（需为站点或刷流任务添加标签）
+ 新增：刷流任务 支持当前站点下载中任务数限制（需为站点或刷流任务添加标签）

感谢大佬一直以来继续维护 nas-tools，不知道我的这个需求算不算小众，如果实在没必要的话大佬把 PR 关掉就行。

最后祝大家新年快乐~