### PR TITLE
fix: telegram api 代理默认值无法编辑为空

### DIFF
--- a/config.py
+++ b/config.py
@@ -238,7 +238,7 @@ class Config(object):
         return None
 
     def get_telegram_domain(self):
-        telegram_domain = (self.get_config('laboratory') or {}).get("telegram_domain", "https://api.telegram.org")
+        telegram_domain = (self.get_config('laboratory') or {}).get("telegram_domain") or "https://api.telegram.org"
         if telegram_domain and telegram_domain.endswith("/"):
             telegram_domain = telegram_domain[:-1]
         return telegram_domain


### PR DESCRIPTION
如果该字段之前有设定过值，则后续清空该字段会获得空链接。