### PR TITLE
fix(brushtask): 修复刷流任务bug

### DIFF
--- a/app/brushtask.py
+++ b/app/brushtask.py
@@ -683,7 +683,6 @@ class BrushTask(object):
                          cookie,
                          ua,
                          proxy):
-        log.info("【Brush】torrent：%s  size: %d" % (title, torrent_size))
         """
         检查种子是否符合刷流过滤条件
         :param rss_rule: 过滤条件字典
@@ -711,31 +710,25 @@ class BrushTask(object):
                         else:
                             max_size = 0
                         if rule_sizes[0] == "gt" and float(torrent_size) < float(min_size) * 1024 ** 3:
-                            log.info("【Brush】torrent：%s  err1" % title)
                             return False
                         if rule_sizes[0] == "lt" and float(torrent_size) > float(min_size) * 1024 ** 3:
-                            log.info("【Brush】torrent：%s  err2" % title)
                             return False
                         if rule_sizes[0] == "bw" and not float(min_size) * 1024 ** 3 < float(torrent_size) < float(
                                 max_size) * 1024 ** 3:
-                            log.info("【Brush】torrent：%s  err3" % title)
                             return False
 
             # 检查包含规则
             if rss_rule.get("include"):
                 if not re.search(r"%s" % rss_rule.get("include"), title):
-                    log.info("【Brush】torrent：%s include: %s err4" % (title, rss_rule.get("include")))
                     return False
 
             # 检查排除规则
             if rss_rule.get("exclude"):
                 if re.search(r"%s" % rss_rule.get("exclude"), title):
-                    log.info("【Brush】torrent：%s exclude: %s err5" % (title, rss_rule.get("exclude")))
                     return False
 
             # 站点流控
             if self.sites.check_ratelimit(siteid):
-                log.info("【Brush】torrent：%s err6" % (title))
                 return False
 
             torrent_attr = self.siteconf.check_torrent_attr(torrent_url=torrent_url,
@@ -748,17 +741,17 @@ class BrushTask(object):
             # 检查免费状态
             if rss_rule.get("free") == "FREE":
                 if not torrent_attr.get("free"):
-                    log.info("【Brush】不是一个FREE资源，跳过")
+                    log.debug("【Brush】不是一个FREE资源，跳过")
                     return False
             elif rss_rule.get("free") == "2XFREE":
                 if not torrent_attr.get("2xfree"):
-                    log.info("【Brush】不是一个2XFREE资源，跳过")
+                    log.debug("【Brush】不是一个2XFREE资源，跳过")
                     return False
 
             # 检查HR状态
             if rss_rule.get("hr"):
                 if torrent_attr.get("hr"):
-                    log.info("【Brush】这是一个H&R资源，跳过")
+                    log.debug("【Brush】这是一个H&R资源，跳过")
                     return False
 
             # 检查做种人数
@@ -780,15 +773,15 @@ class BrushTask(object):
                     else:
                         max_count = sys.maxsize
                     if peer_counts[0] == "gt" and torrent_peer_count <= min_count:
-                        log.info("【Brush】%s `判断做种数, 判断条件: peer_count:%d %s threshold:%d" % (
+                        log.debug("【Brush】%s `判断做种数, 判断条件: peer_count:%d %s threshold:%d" % (
                             title, torrent_peer_count, peer_counts[0], min_count))
                         return False
                     if peer_counts[0] == "lt" and torrent_peer_count >= min_count:
-                        log.info("【Brush】%s `判断做种数, 判断条件: peer_count:%d %s threshold:%d" % (
+                        log.debug("【Brush】%s `判断做种数, 判断条件: peer_count:%d %s threshold:%d" % (
                             title, torrent_peer_count, peer_counts[0], min_count))
                         return False
                     if peer_counts[0] == "bw" and not (min_count <= torrent_peer_count <= max_count):
-                        log.info("【Brush】%s `判断做种数, 判断条件: left:%d %s peer_count:%d %s right:%d" % (
+                        log.debug("【Brush】%s `判断做种数, 判断条件: left:%d %s peer_count:%d %s right:%d" % (
                             title, min_count, peer_counts[0], torrent_peer_count, peer_counts[0], max_count))
                         return False
 
@@ -803,20 +796,20 @@ class BrushTask(object):
                     localnowtime = datetime.now().astimezone(localtz)
                     localpubdate = pubdate.astimezone(localtz)
                     pudate_hour = int(localnowtime.timestamp() - localpubdate.timestamp()) / 3600
-                    log.info('【Brush】发布时间：%s，当前时间：%s，时间间隔：%f hour' % (
+                    log.debug('【Brush】发布时间：%s，当前时间：%s，时间间隔：%f hour' % (
                         localpubdate.isoformat(), localnowtime.isoformat(), pudate_hour))
                     if rule_pubdates[0] == "lt" and pudate_hour >= float(min_pubdate):
-                        log.info("【Brush】%s `判断发布时间, 判断条件: pubdate: %s %d" % (
+                        log.debug("【Brush】%s `判断发布时间, 判断条件: pubdate: %s %d" % (
                             title, rule_pubdates[0], float(min_pubdate)))
                         return False
                     if rule_pubdates[0] == "gt" and pudate_hour <= float(min_pubdate):
-                        log.info("【Brush】%s `判断发布时间, 判断条件: pubdate: %s %d" % (
+                        log.debug("【Brush】%s `判断发布时间, 判断条件: pubdate: %s %d" % (
                             title, rule_pubdates[0], float(min_pubdate)))
                         return False
                     if rule_pubdates[0] == "bw" and (
                             not max_pubdate or not (
                             float(min_pubdate) <= pudate_hour <= float(max_pubdate))):
-                        log.info("【Brush】%s `判断发布时间, 判断条件: pubdate: %s %d %d" % (
+                        log.debug("【Brush】%s `判断发布时间, 判断条件: pubdate: %s %d %d" % (
                             title, rule_pubdates[0], float(min_pubdate), float(max_pubdate or 0)))
                         return False
 
@@ -922,7 +915,7 @@ class BrushTask(object):
             # ID
             torrent_id = torrent.hashString
             # 做种时间
-            if not torrent.date_done or torrent.date_done.timestamp() < 1:
+            if not hasattr(torrent, 'date_done') or not torrent.date_done or torrent.date_done.timestamp() < 1:
                 seeding_time = 0
             else:
                 seeding_time = date_now - int(torrent.date_done.timestamp())


### PR DESCRIPTION
当刷流种子被各种条件限制时会导致后续即使条件符合也没法刷流

这些条件很多都是变动的，如：
- 包含规则、排除规则（会根据页面修改变动）
- 站点流控（随时可变）
- 免费\hr状态（种子类型可能随时变化）
- 做种人数
- 下载、上传限制速度
- 正在下载的任务数

当条件变动后，之前检查的种子应该要继续检查，原先只要种子一次检查失败就不会再检查了，会导致很多种子因此无法下载刷流