### PR TITLE
feat(media): 将删除特殊字符改为选项控制

### DIFF
--- a/app/utils/string_utils.py
+++ b/app/utils/string_utils.py
@@ -305,16 +305,19 @@ class StringUtils:
         if not name:
             return None
 
+        media = Config().get_config('media')
+        cleaned_name = name
+
         replacement_dict = {
-            r"[*?\\/\"<>~|,，？]": "",
+            r"[*?\\/\"<>~|,]": "",
             r"[\s]+": " ",
         }
-
-        cleaned_name = name
+        filename_keep_punctuation = media.get("filename_keep_punctuation", False) or False
+        if not filename_keep_punctuation:
+            replacement_dict[r"[，？]"] = ""
         for pattern, replacement in replacement_dict.items():
             cleaned_name = re.sub(pattern, replacement, cleaned_name, flags=re.IGNORECASE).strip()
 
-        media = Config().get_config('media')
         filename_prefer_barre = media.get("filename_prefer_barre", False) or False
         if filename_prefer_barre:
             cleaned_name = cleaned_name.replace(":", " - ").replace("：", " - ")

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -105,6 +105,8 @@ media:
   tmdb_include_adult: false
   # 【使用横杠替换冒号】：如开启，文件名中的中英文冒号将替换为横杠
   filename_prefer_barre: false
+  # 【保留中文标点符号】：如开启，文件名中的中文问号、逗号将被保留
+  filename_keep_punctuation: false
   # 【获取视频元数据】：如开启，视频文件名不包含视频元数据的情况，则会通过ffmpeg获取，将会大幅增加转移时间，低配置机器不建议开启
   ffmpeg_video_meta: false
   # 【已整理媒体名称跟随TMDB变化】：开启则会一直与TMDB同步但是会创建多个文件夹；关闭后将会保持与TMDB信息改变之前的名称一致，不会再创建新文件夹

--- a/web/templates/setting/basic.html
+++ b/web/templates/setting/basic.html
@@ -450,6 +450,19 @@
                 </div>
             </div>
           </div>
+          <div class="row">
+            <div class="col-lg">
+              <div class="mb-3">
+                <label class="form-check form-switch">
+                  <input class="form-check-input" type="checkbox" id="media.filename_keep_punctuation" {% if
+                    Config.media.filename_keep_punctuation %}checked{% endif %}>
+                  <span class="form-check-label">保留中文标点符号 <span class="form-help"
+                                                                      title="开启后，文件名中的中文问号、逗号将被保留。"
+                                                                      data-bs-toggle="tooltip">?</span></span>
+                </label>
+              </div>
+            </div>
+          </div>
         </div>
           <div class="card-footer">
                 <div class="row align-items-center">


### PR DESCRIPTION
选项默认关闭，与修改前行为一致。

起因是 tinyMediaManager 刮削的文件名与 nas-tools 刮削的不一样，一看是 nas-tools 在净化文件名时将中文逗号和问号删掉了：[string_utils.py#L309](https://github.com/hsuyelin/nas-tools/blob/1c41cd43508e877b520027c70b23f1567ab34561/app/utils/string_utils.py#L309)，而这两个符号在文件系统中是允许的。

不知道当初这段代码的作者有什么特殊考虑，删了问号逗号没删句号，所以加个开关允许更改行为。