### PR TITLE
修复自定义识别词不使用媒体分组的问题

### DIFF
--- a/app/helper/db_helper.py
+++ b/app/helper/db_helper.py
@@ -2296,9 +2296,8 @@ class DbHelper:
         """
         if gid:
             return self._db.query(CUSTOMWORDGROUPS).filter(CUSTOMWORDGROUPS.ID == int(gid)).all()
-        if tmdbid and gtype:
-            return self._db.query(CUSTOMWORDGROUPS).filter(CUSTOMWORDGROUPS.TMDBID == int(tmdbid),
-                                                           CUSTOMWORDGROUPS.TYPE == int(gtype)).all()
+        if tmdbid:
+            return self._db.query(CUSTOMWORDGROUPS).filter(CUSTOMWORDGROUPS.TMDBID == int(tmdbid)).all()
         return self._db.query(CUSTOMWORDGROUPS).all()
 
     def is_custom_word_group_existed(self, tmdbid=None, gtype=None):

--- a/app/helper/words_helper.py
+++ b/app/helper/words_helper.py
@@ -2,22 +2,20 @@ import regex as re
 import cn2an
 
 from app.helper.db_helper import DbHelper
-from app.utils.commons import singleton
 from app.utils.exception_utils import ExceptionUtils
 
 
-@singleton
 class WordsHelper:
     dbhelper = None
     # 识别词
     words_info = []
 
-    def __init__(self):
-        self.init_config()
+    def __init__(self, gid=None):
+        self.init_config(gid=gid)
 
-    def init_config(self):
+    def init_config(self, gid=None):
         self.dbhelper = DbHelper()
-        self.words_info = self.dbhelper.get_custom_words(enabled=1)
+        self.words_info = self.dbhelper.get_custom_words(gid=gid, enabled=1)
 
     def process(self, title):
         # 错误信息

--- a/app/media/media.py
+++ b/app/media/media.py
@@ -824,7 +824,13 @@ class Media:
                                                      append_to_response=append_to_response)
             else:
                 file_media_info = None
-        # 赋值TMDB信息并返回
+        # 重新处理 meta_info，赋值TMDB信息并返回
+        meta_info = MetaInfo(title, subtitle=subtitle, tmdb_id=file_media_info.get('id'))
+        if not meta_info.get_name() or not meta_info.type:
+            log.warn("【Rmt】%s 未识别出有效信息！" % meta_info.org_string)
+            return None
+        if mtype:
+            meta_info.type = mtype
         meta_info.set_tmdb_info(file_media_info)
         return meta_info
 

--- a/app/media/meta/metainfo.py
+++ b/app/media/meta/metainfo.py
@@ -36,15 +36,21 @@ def MetaInfo(title,
     # 记录原始名称
     org_title = title
     # 应用自定义识别词，获取识别词处理后名称
-    rev_title, msg, used_info = WordsHelper().process(title)
+    gid = [-1]
+    if tmdb_id:
+        custom_words_group = WordsHelper().get_custom_word_groups(tmdbid=tmdb_id)
+        if len(custom_words_group) != 0:
+            gid.append(custom_words_group[0].ID)
+    rev_title = title
+    for i in gid:
+        rev_title, msg, used_info = WordsHelper(gid=i).process(rev_title)
+        if msg:
+            for msg_item in msg:
+                log.warn("【Meta】%s" % msg_item)
     if rev_title and ffmpeg_video_meta_enable and filePath:
         rev_title = __complete_rev_title(rev_title, filePath)
     if subtitle:
         subtitle, _, _ = WordsHelper().process(subtitle)
-
-    if msg:
-        for msg_item in msg:
-            log.warn("【Meta】%s" % msg_item)
 
     # 判断是否处理文件
     if org_title and os.path.splitext(org_title)[-1] in RMT_MEDIAEXT:


### PR DESCRIPTION
在以前的逻辑中，自定义识别词是一个单例。所有的识别词，无论是全局自定义识别词还是根据影视来分组的识别词都会应用到所有影视的名称识别中；现在，名称识别将真正根据自定义识别词中的分组来进行应用。

我在编写这个 pr 前，纠结了许久是否应该更改这个逻辑，毕竟这个逻辑存在已久却没有人提出疑问。也许以前的设计理念只是起分组作用，方便用户记忆当初识别词是为哪个影视而编写的；但是在 web 页面中，通用分组的标识让我更加坚定原来的逻辑是不符合原来的设计理念的；同时，原来的 `get_custom_word_groups` 方法设计了 `tmdbid` 的字段却在全文中没有使用，这更让我坚定了这是原来就要实现的逻辑。也希望大家一起考虑一下这部分究竟应该如何实现。