### PR TITLE
[重要] 修复 #684 导致的仅通用自定义识别词组被应用的问题

### DIFF
--- a/app/media/media.py
+++ b/app/media/media.py
@@ -743,95 +743,6 @@ class Media:
             return None
         if mtype:
             meta_info.type = mtype
-        media_key = self.__make_cache_key(meta_info)
-        if not cache or not self.meta.get_meta_data_by_key(media_key):
-            # 缓存没有或者强制不使用缓存
-            if meta_info.type != MediaType.TV and not meta_info.year:
-                file_media_info = self.__search_multi_tmdb(file_media_name=meta_info.get_name())
-            else:
-                if meta_info.type == MediaType.TV:
-                    # 确定是电视
-                    file_media_info = self.__search_tmdb(file_media_name=meta_info.get_name(),
-                                                         first_media_year=meta_info.year,
-                                                         search_type=meta_info.type,
-                                                         media_year=meta_info.year,
-                                                         season_number=meta_info.begin_season
-                                                         )
-                    if not file_media_info and meta_info.year and self._rmt_match_mode == MatchMode.NORMAL and not strict:
-                        # 非严格模式下去掉年份再查一次
-                        file_media_info = self.__search_tmdb(file_media_name=meta_info.get_name(),
-                                                             search_type=meta_info.type
-                                                             )
-                else:
-                    # 有年份先按电影查
-                    file_media_info = self.__search_tmdb(file_media_name=meta_info.get_name(),
-                                                         first_media_year=meta_info.year,
-                                                         search_type=MediaType.MOVIE
-                                                         )
-                    # 没有再按电视剧查
-                    if not file_media_info:
-                        file_media_info = self.__search_tmdb(file_media_name=meta_info.get_name(),
-                                                             first_media_year=meta_info.year,
-                                                             search_type=MediaType.TV
-                                                             )
-                    if not file_media_info and self._rmt_match_mode == MatchMode.NORMAL and not strict:
-                        # 非严格模式下去掉年份和类型再查一次
-                        file_media_info = self.__search_multi_tmdb(file_media_name=meta_info.get_name())
-            if not file_media_info and self._search_tmdbweb:
-                # 从网站查询
-                file_media_info = self.__search_tmdb_web(file_media_name=meta_info.get_name(),
-                                                         mtype=meta_info.type)
-            if not file_media_info and self._chatgpt_enable:
-                # 通过ChatGPT查询
-                mtype, seaons, episodes, file_media_info = self.__search_chatgpt(file_name=title,
-                                                                                 mtype=meta_info.type)
-                # 修正类型和集数
-                meta_info.type = mtype
-                if not meta_info.get_season_string():
-                    meta_info.set_season(seaons)
-                if not meta_info.get_episode_string():
-                    meta_info.set_episode(episodes)
-            if not file_media_info and self._search_keyword:
-                # 关键字猜测
-                cache_name = cacheman["tmdb_supply"].get(meta_info.get_name())
-                is_movie = False
-                if not cache_name:
-                    cache_name, is_movie = self.__search_engine(meta_info.get_name())
-                    cacheman["tmdb_supply"].set(meta_info.get_name(), cache_name)
-                if cache_name:
-                    log.info("【Meta】开始辅助查询：%s ..." % cache_name)
-                    if is_movie:
-                        file_media_info = self.__search_tmdb(file_media_name=cache_name, search_type=MediaType.MOVIE)
-                    else:
-                        file_media_info = self.__search_multi_tmdb(file_media_name=cache_name)
-            # 补充全量信息
-            if file_media_info and not file_media_info.get("genres"):
-                file_media_info = self.get_tmdb_info(mtype=file_media_info.get("media_type"),
-                                                     tmdbid=file_media_info.get("id"),
-                                                     chinese=chinese,
-                                                     append_to_response=append_to_response)
-            # 保存到缓存
-            if file_media_info is not None:
-                self.__insert_media_cache(media_key=media_key,
-                                          file_media_info=file_media_info)
-        else:
-            # 使用缓存信息
-            cache_info = self.meta.get_meta_data_by_key(media_key)
-            if cache_info.get("id"):
-                file_media_info = self.get_tmdb_info(mtype=cache_info.get("type"),
-                                                     tmdbid=cache_info.get("id"),
-                                                     chinese=chinese,
-                                                     append_to_response=append_to_response)
-            else:
-                file_media_info = None
-        # 重新处理 meta_info，赋值TMDB信息并返回
-        meta_info = MetaInfo(title, subtitle=subtitle, tmdb_id=file_media_info.get('id'))
-        if not meta_info.get_name() or not meta_info.type:
-            log.warn("【Rmt】%s 未识别出有效信息！" % meta_info.org_string)
-            return None
-        if mtype:
-            meta_info.type = mtype
-        meta_info.set_tmdb_info(file_media_info)
         return meta_info
 
     def __insert_media_cache(self, media_key, file_media_info):
@@ -2363,3 +2274,87 @@ class Media:
             result.append({"制作公司": production_company})
 
         return result
+
+    def get_tmdb_info_by_meta_info(self, meta_info, cache=True, chinese=True, append_to_response=None, strict=None):
+        media_key = self.__make_cache_key(meta_info)
+        if not cache or not self.meta.get_meta_data_by_key(media_key):
+            # 缓存没有或者强制不使用缓存
+            if meta_info.type != MediaType.TV and not meta_info.year:
+                file_media_info = self.__search_multi_tmdb(file_media_name=meta_info.get_name())
+            else:
+                if meta_info.type == MediaType.TV:
+                    # 确定是电视
+                    file_media_info = self.__search_tmdb(file_media_name=meta_info.get_name(),
+                                                         first_media_year=meta_info.year,
+                                                         search_type=meta_info.type,
+                                                         media_year=meta_info.year,
+                                                         season_number=meta_info.begin_season
+                                                         )
+                    if not file_media_info and meta_info.year and self._rmt_match_mode == MatchMode.NORMAL and not strict:
+                        # 非严格模式下去掉年份再查一次
+                        file_media_info = self.__search_tmdb(file_media_name=meta_info.get_name(),
+                                                             search_type=meta_info.type
+                                                             )
+                else:
+                    # 有年份先按电影查
+                    file_media_info = self.__search_tmdb(file_media_name=meta_info.get_name(),
+                                                         first_media_year=meta_info.year,
+                                                         search_type=MediaType.MOVIE
+                                                         )
+                    # 没有再按电视剧查
+                    if not file_media_info:
+                        file_media_info = self.__search_tmdb(file_media_name=meta_info.get_name(),
+                                                             first_media_year=meta_info.year,
+                                                             search_type=MediaType.TV
+                                                             )
+                    if not file_media_info and self._rmt_match_mode == MatchMode.NORMAL and not strict:
+                        # 非严格模式下去掉年份和类型再查一次
+                        file_media_info = self.__search_multi_tmdb(file_media_name=meta_info.get_name())
+            if not file_media_info and self._search_tmdbweb:
+                # 从网站查询
+                file_media_info = self.__search_tmdb_web(file_media_name=meta_info.get_name(),
+                                                         mtype=meta_info.type)
+            if not file_media_info and self._chatgpt_enable:
+                # 通过ChatGPT查询
+                mtype, seaons, episodes, file_media_info = self.__search_chatgpt(file_name=meta_info.org_string,
+                                                                                 mtype=meta_info.type)
+                # 修正类型和集数
+                meta_info.type = mtype
+                if not meta_info.get_season_string():
+                    meta_info.set_season(seaons)
+                if not meta_info.get_episode_string():
+                    meta_info.set_episode(episodes)
+            if not file_media_info and self._search_keyword:
+                # 关键字猜测
+                cache_name = cacheman["tmdb_supply"].get(meta_info.get_name())
+                is_movie = False
+                if not cache_name:
+                    cache_name, is_movie = self.__search_engine(meta_info.get_name())
+                    cacheman["tmdb_supply"].set(meta_info.get_name(), cache_name)
+                if cache_name:
+                    log.info("【Meta】开始辅助查询：%s ..." % cache_name)
+                    if is_movie:
+                        file_media_info = self.__search_tmdb(file_media_name=cache_name, search_type=MediaType.MOVIE)
+                    else:
+                        file_media_info = self.__search_multi_tmdb(file_media_name=cache_name)
+            # 补充全量信息
+            if file_media_info and not file_media_info.get("genres"):
+                file_media_info = self.get_tmdb_info(mtype=file_media_info.get("media_type"),
+                                                     tmdbid=file_media_info.get("id"),
+                                                     chinese=chinese,
+                                                     append_to_response=append_to_response)
+            # 保存到缓存
+            if file_media_info is not None:
+                self.__insert_media_cache(media_key=media_key,
+                                          file_media_info=file_media_info)
+        else:
+            # 使用缓存信息
+            cache_info = self.meta.get_meta_data_by_key(media_key)
+            if cache_info.get("id"):
+                file_media_info = self.get_tmdb_info(mtype=cache_info.get("type"),
+                                                     tmdbid=cache_info.get("id"),
+                                                     chinese=chinese,
+                                                     append_to_response=append_to_response)
+            else:
+                file_media_info = None
+        return file_media_info

--- a/app/media/meta/metainfo.py
+++ b/app/media/meta/metainfo.py
@@ -10,6 +10,7 @@ from app.utils.types import MediaType
 from app.utils import StringUtils
 from config import Config, RMT_MEDIAEXT
 from app.helper import FfmpegHelper
+from typing import List
 
 def MetaInfo(title,
              subtitle=None,
@@ -27,7 +28,29 @@ def MetaInfo(title,
     :param mtype: 指定识别类型，为空则自动识别类型
     :return: MetaAnime、MetaVideo
     """
+    gid = [-1]
+    rev_title = title
+    laboratory = Config().get_config('laboratory')
+    recognize_enhance_enable = False
+    if laboratory:
+        recognize_enhance_enable = laboratory.get('recognize_enhance_enable', False) or False
 
+    def process_title(rev_title, tmdb_id, gid, subtitle):
+        if tmdb_id:
+            custom_words_group = WordsHelper().get_custom_word_groups(tmdbid=tmdb_id)
+            if len(custom_words_group) != 0:
+                gid.append(custom_words_group[0].ID)
+        for i in gid:
+            rev_title, msg, used_info = WordsHelper(gid=i).process(rev_title)
+            if msg:
+                for msg_item in msg:
+                    log.warn("【Meta】%s" % msg_item)
+        if rev_title and ffmpeg_video_meta_enable and filePath:
+            rev_title = __complete_rev_title(rev_title, filePath)
+        if subtitle:
+            subtitle, _, _ = WordsHelper().process(subtitle)
+        return rev_title, subtitle, used_info
+    
     # 使用ffmpeg获取视频元数据状态
     media = Config().get_config('media')
     ffmpeg_video_meta_enable = False
@@ -36,21 +59,8 @@ def MetaInfo(title,
     # 记录原始名称
     org_title = title
     # 应用自定义识别词，获取识别词处理后名称
-    gid = [-1]
-    if tmdb_id:
-        custom_words_group = WordsHelper().get_custom_word_groups(tmdbid=tmdb_id)
-        if len(custom_words_group) != 0:
-            gid.append(custom_words_group[0].ID)
-    rev_title = title
-    for i in gid:
-        rev_title, msg, used_info = WordsHelper(gid=i).process(rev_title)
-        if msg:
-            for msg_item in msg:
-                log.warn("【Meta】%s" % msg_item)
-    if rev_title and ffmpeg_video_meta_enable and filePath:
-        rev_title = __complete_rev_title(rev_title, filePath)
-    if subtitle:
-        subtitle, _, _ = WordsHelper().process(subtitle)
+
+    rev_title, subtitle, used_info = process_title(rev_title, tmdb_id, gid, subtitle)
 
     # 判断是否处理文件
     if org_title and os.path.splitext(org_title)[-1] in RMT_MEDIAEXT:
@@ -58,18 +68,26 @@ def MetaInfo(title,
     else:
         fileflag = False
 
-    laboratory = Config().get_config('laboratory')
-    recognize_enhance_enable = False
-    if laboratory:
-        recognize_enhance_enable = laboratory.get('recognize_enhance_enable', False) or False
-
-    if recognize_enhance_enable:
-         meta_info = MetaVideoV2(rev_title, subtitle, fileflag, filePath, media_type, cn_name, en_name, tmdb_id, imdb_id)
-    else:
-        if mtype == MediaType.ANIME or is_anime(rev_title):
-            meta_info = MetaAnime(rev_title, subtitle, fileflag, filePath, media_type, cn_name, en_name, tmdb_id, imdb_id)
+    def gen_meta_info(rev_title, subtitle, fileflag, filePath, media_type, cn_name, en_name, tmdb_id, imdb_id):
+        if recognize_enhance_enable:
+             meta_info = MetaVideoV2(rev_title, subtitle, fileflag, filePath, media_type, cn_name, en_name, tmdb_id, imdb_id)
         else:
-            meta_info = MetaVideo(rev_title, subtitle, fileflag, filePath, media_type, cn_name, en_name, tmdb_id, imdb_id)
+            if mtype == MediaType.ANIME or is_anime(rev_title):
+                meta_info = MetaAnime(rev_title, subtitle, fileflag, filePath, media_type, cn_name, en_name, tmdb_id, imdb_id)
+            else:
+                meta_info = MetaVideo(rev_title, subtitle, fileflag, filePath, media_type, cn_name, en_name, tmdb_id, imdb_id)
+        return meta_info
+    
+    meta_info = gen_meta_info(rev_title, subtitle, fileflag, filePath, media_type, cn_name, en_name, tmdb_id, imdb_id)
+    
+    # 为了正确应用识别词，我们再次生成一遍 MetaInfo
+    if not tmdb_id:
+        from app.media import Media
+        file_media_info = Media().get_tmdb_info_by_meta_info(meta_info=meta_info)
+        if file_media_info:
+            tmdb_id = file_media_info.get('id')
+            rev_title, subtitle, used_info = process_title(rev_title, tmdb_id, gid, subtitle)
+            meta_info = gen_meta_info(rev_title, subtitle, fileflag, filePath, media_type, cn_name, en_name, tmdb_id, imdb_id)
     # 设置原始名称
     meta_info.org_string = org_title
     # 设置识别词处理后名称

--- a/app/media/meta/metainfo.py
+++ b/app/media/meta/metainfo.py
@@ -96,6 +96,7 @@ def MetaInfo(title,
     meta_info.ignored_words = used_info.get("ignored")
     meta_info.replaced_words = used_info.get("replaced")
     meta_info.offset_words = used_info.get("offset")
+    meta_info.set_tmdb_info(file_media_info)
 
     return meta_info
 

--- a/app/media/meta/metainfo.py
+++ b/app/media/meta/metainfo.py
@@ -60,7 +60,7 @@ def MetaInfo(title,
     org_title = title
     # 应用自定义识别词，获取识别词处理后名称
 
-    rev_title, subtitle, used_info = process_title(rev_title, tmdb_id, gid, subtitle)
+    rev_title, subtitle, global_used_info = process_title(rev_title, tmdb_id, gid, subtitle)
 
     # 判断是否处理文件
     if org_title and os.path.splitext(org_title)[-1] in RMT_MEDIAEXT:
@@ -79,6 +79,11 @@ def MetaInfo(title,
         return meta_info
     
     meta_info = gen_meta_info(rev_title, subtitle, fileflag, filePath, media_type, cn_name, en_name, tmdb_id, imdb_id)
+
+    # 设置应用的识别词
+    meta_info.ignored_words = global_used_info.get("ignored")
+    meta_info.replaced_words = global_used_info.get("replaced")
+    meta_info.offset_words = global_used_info.get("offset")
     
     # 为了正确应用识别词，我们再次生成一遍 MetaInfo
     if not tmdb_id:
@@ -88,14 +93,17 @@ def MetaInfo(title,
             tmdb_id = file_media_info.get('id')
             rev_title, subtitle, used_info = process_title(rev_title, tmdb_id, gid, subtitle)
             meta_info = gen_meta_info(rev_title, subtitle, fileflag, filePath, media_type, cn_name, en_name, tmdb_id, imdb_id)
+            # 设置应用的识别词
+            meta_info.ignored_words = used_info.get("ignored")
+            meta_info.replaced_words = used_info.get("replaced")
+            meta_info.offset_words = used_info.get("offset")
+            meta_info.ignored_words.extend(global_used_info.get("ignored"))
+            meta_info.replaced_words.extend(global_used_info.get("replaced"))
+            meta_info.offset_words.extend(global_used_info.get("offset"))
     # 设置原始名称
     meta_info.org_string = org_title
     # 设置识别词处理后名称
     meta_info.rev_string = rev_title
-    # 设置应用的识别词
-    meta_info.ignored_words = used_info.get("ignored")
-    meta_info.replaced_words = used_info.get("replaced")
-    meta_info.offset_words = used_info.get("offset")
     meta_info.set_tmdb_info(file_media_info)
 
     return meta_info


### PR DESCRIPTION
因为依赖 `MetaInfo` 接口的函数众多，所以将 TMDB 查询逻辑由 `get_media_info` 移至 `MetaInfo`，这样应该处处都是按照正确的逻辑来应用自定义词组了。