### PR TITLE
feat: forward_auth

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import hashlib
+import ipaddress
 import mimetypes
 import os.path
 import re
@@ -168,10 +169,35 @@ def login():
                                img_link=img_link,
                                err_msg=errmsg)
 
-    user_name = request.headers.get("Remote-User")
     log.info("from: %s" % request.access_route)
-    oidc = Config().get_config('app').get('oidc_enable')
-    if oidc and user_name:
+    proxy_ip = request.environ.get('werkzeug.proxy_fix.orig', {}).get('REMOTE_ADDR') or request.remote_addr
+
+    # 获取forward auth相关配置
+    forward_auth = Config().get_config('app').get('forward_auth', {})
+    forward_auth_enable = forward_auth.get("enable", False)
+    trusted_proxies = forward_auth.get("trusted_proxies", ["127.0.0.1"])
+    forward_auth_header = forward_auth.get("header", "Remote-User")
+
+    if isinstance(trusted_proxies, str):
+        trusted_proxies = [trusted_proxies]
+
+    # 检查代理IP是否在受信任代理列表中
+    try:
+        is_trusted_forward = any(
+            ipaddress.ip_address(proxy_ip) in ipaddress.ip_network(proxy, strict=False) for proxy in trusted_proxies)
+        if forward_auth_enable and not is_trusted_forward:
+            log.warn(f"代理IP不在受信任代理列表中, proxy_ip={proxy_ip}, trusted_proxies={trusted_proxies}")
+    except ValueError as e:
+        log.error(f"app.forward_auth.trusted_proxies 配置错误, {e}")
+        is_trusted_forward = False
+
+    # 获取用户名称
+    if forward_auth_enable and is_trusted_forward:
+        user_name = request.headers.get(forward_auth_header)
+    else:
+        user_name = None
+
+    if forward_auth_enable and is_trusted_forward and user_name:
         GoPage = request.form.get('next') or ""
         if GoPage.startswith('/'):
             GoPage = GoPage[1:]


### PR DESCRIPTION
基于 #600 修改
感谢 @PterX 

我认为这种身份认证属于`forward_auth` 而不是 `oidc` :)
所以我将oidc修改为forward_auth
添加 trusted_proxies 防止伪造header
添加 forward_auth_header 允许修改forward_auth获取用户的header

修改后的配置文件样式如下
```yaml
...

app:
  # forward_auth 配置块
  forward_auth:
    # 是否启用forward_auth
    enable: true
    # 可信代理地址
    trusted_proxies:
      - 192.168.1.0/24
    # forward_auth添加的用户名header
    header: X-Forward-Auth-Username

...
```