### PR TITLE
修复纵使种子内的文件名含有所有需要的剧集时，如果标题或副标题没有写明集数范围时，该种子也不会被下载的问题

### DIFF
--- a/app/downloader/downloader.py
+++ b/app/downloader/downloader.py
@@ -866,7 +866,14 @@ class Downloader:
                                 continue
                             item_episodes = item.get_episode_list()
                             if not item_episodes:
-                                continue
+                                # 有时，就算标题副标题没有集数，种子内文件名本身仍然可能是含有集数的。我们打开种子文件来一探究竟。
+                                torrent_episodes, torrent_path = self.get_torrent_episodes(
+                                    url=item.enclosure,
+                                    page_url=item.page_url)
+                                if not torrent_episodes:
+                                    continue
+                                else:
+                                    item_episodes = torrent_episodes
                             # 为需要集的子集则下载
                             if set(item_episodes).issubset(set(need_episodes)):
                                 _, download_id = __download(item)

--- a/app/media/meta/metainfo.py
+++ b/app/media/meta/metainfo.py
@@ -42,13 +42,13 @@ def MetaInfo(title,
                 gid.append(custom_words_group[0].ID)
         for i in gid:
             rev_title, msg, used_info = WordsHelper(gid=i).process(rev_title)
+            if subtitle:
+                subtitle, _, _ = WordsHelper(gid=i).process(subtitle)
             if msg:
                 for msg_item in msg:
                     log.warn("【Meta】%s" % msg_item)
         if rev_title and ffmpeg_video_meta_enable and filePath:
             rev_title = __complete_rev_title(rev_title, filePath)
-        if subtitle:
-            subtitle, _, _ = WordsHelper().process(subtitle)
         return rev_title, subtitle, used_info
     
     # 使用ffmpeg获取视频元数据状态


### PR DESCRIPTION
修复纵使种子内的文件名含有所有需要的剧集时，如果标题或副标题没有写明集数范围时，该种子也不会被下载的问题。本 pr 同时修复了副标题仅应用自定义识别词中通用识别词的问题。