### PR TITLE
修复当目录同步未配置识别并重命名时配置项media.min_filesize无效

### DIFF
--- a/app/sync.py
+++ b/app/sync.py
@@ -1,5 +1,6 @@
 import os
 import threading
+import time
 import traceback
 
 from watchdog.events import FileSystemEventHandler
@@ -415,7 +416,11 @@ class Sync(object):
         """
         if self.dbhelper.is_sync_in_history(event_path, target_path):
             return
-        ep_size = os.stat(event_path).st_size
+        ep_size = 0
+        # fix size to small: wait till copy finishes
+        while ep_size != (cur_size := os.stat(event_path).st_size):
+            ep_size = cur_size
+            time.sleep(1)
         if ep_size < self.filetransfer._min_filesize:
             log.info("【Sync】跳过同步 %s size=%.2fMB" % (event_path, ep_size / (1024 * 1024)))
             return

--- a/app/sync.py
+++ b/app/sync.py
@@ -415,6 +415,10 @@ class Sync(object):
         """
         if self.dbhelper.is_sync_in_history(event_path, target_path):
             return
+        ep_size = os.stat(event_path).st_size
+        if ep_size < self.filetransfer._min_filesize:
+            log.info("【Sync】跳过同步 %s size=%.2fMB" % (event_path, ep_size / (1024 * 1024)))
+            return
         log.info("【Sync】开始同步 %s" % event_path)
         try:
             ret, msg = self.filetransfer.link_sync_file(src_path=mon_path,


### PR DESCRIPTION
之前在仅目录同步 不识别 时`media.min_filesize`无效会导致一些小文件被同步，这个PR在仅文件同步时检查event_path文件的大小，跳过同步小于media.min_filesize的文件。

由于FileMonitorHandler目前未处理closed事件，在同步时文件可能处于打开状态导致大小不准确，目前简单的使用while检查直到文件大小不改变
