### PR TITLE
nastool同步目录支持预填写TMDB

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -62,6 +62,7 @@ class CONFIGSYNCPATHS(Base):
     SOURCE = Column(Text)
     DEST = Column(Text)
     UNKNOWN = Column(Text)
+    TMDBID = Column(Text)
     MODE = Column(Text)
     COMPATIBILITY = Column(Integer)
     RENAME = Column(Integer)

--- a/app/helper/db_helper.py
+++ b/app/helper/db_helper.py
@@ -2315,7 +2315,7 @@ class DbHelper:
             return False
 
     @DbPersist(_db)
-    def insert_config_sync_path(self, source, dest, unknown, mode, compatibility, rename, enabled, locating, note=None):
+    def insert_config_sync_path(self, source, dest, unknown, tmdbid, mode, compatibility, rename, enabled, locating, note=None):
         """
         增加目录同步
         """
@@ -2323,6 +2323,7 @@ class DbHelper:
             SOURCE=source,
             DEST=dest,
             UNKNOWN=unknown,
+            TMDBID=tmdbid,
             MODE=mode,
             COMPATIBILITY=int(compatibility),
             RENAME=int(rename),

--- a/web/action.py
+++ b/web/action.py
@@ -1304,6 +1304,7 @@ class WebAction:
         source = data.get("from")
         dest = data.get("to")
         unknown = data.get("unknown")
+        tmdbid = data.get("tmdbid")
         mode = data.get("syncmod")
         compatibility = data.get("compatibility")
         rename = data.get("rename")
@@ -1343,6 +1344,7 @@ class WebAction:
         _sync.insert_sync_path(source=source,
                                dest=dest,
                                unknown=unknown,
+                               tmdbid=tmdbid,
                                mode=mode,
                                compatibility=compatibility,
                                rename=rename,

--- a/web/apiv1.py
+++ b/web/apiv1.py
@@ -2060,6 +2060,7 @@ class SyncDirectoryUpdate(ClientResource):
     parser.add_argument('from', type=str, help='源目录', location='form', required=True)
     parser.add_argument('to', type=str, help='目的目录', location='form')
     parser.add_argument('unknown', type=str, help='未知目录', location='form')
+    parser.add_argument('tmdbid', type=str, help='TMDB ID', location='form')
     parser.add_argument('syncmod', type=str, help='同步模式', location='form')
     parser.add_argument('compatibility', type=str, help='兼容模式', location='form')
     parser.add_argument('rename', type=str, help='重命名', location='form')

--- a/web/templates/setting/directorysync.html
+++ b/web/templates/setting/directorysync.html
@@ -80,6 +80,12 @@
                   </div>
                 </div>
                 <div class="datagrid-item">
+                  <div class="datagrid-title">TMDBID</div>
+                  <div class="datagrid-content">
+                    {{ Attr.tmdbid or '' }}
+                  </div>
+                </div>
+                <div class="datagrid-item">
                   <div class="datagrid-title">同步方式</div>
                   <div class="datagrid-content">
                     <span class="badge">{{ Attr.syncmod_name }}</span>
@@ -171,6 +177,17 @@
                          placeholder="留空不转移未识别文件" autocomplete="off">
             </div>
           </div>
+          <div class="col-lg-4">
+            <div class="mb-3">
+              <label class="form-label">TMDB ID <span class="form-help"
+                                                                title="TMDB ID为预先填写的TMBD ID， 会在监听模式下持续按照此ID同步文件"
+                                                                data-bs-toggle="tooltip">?</span></label>
+              <div class="input-group">
+                <input type="text" value="" id="sync_path_tmdbid" class="form-control" placeholder="留空不设置">
+                <button class="btn" type="button" onclick="show_search_tmdbid_modal('sync_path_tmdbid', 'modal-directory')">查询</button>
+              </div>
+            </div>
+          </div>
           <div class="col-lg-6">
             <div class="mb-3">
               <label class="form-label required">同步方式 <span class="form-help"
@@ -230,6 +247,7 @@
     $("#sync_path_from").val('');
     $("#sync_path_to").val('');
     $("#sync_path_unknown").val('');
+    $("#sync_path_tmdbid").val('');
     $("#sync_path_compatibility").prop("checked", false);
     $("#sync_path_rename").prop("checked", true);
     $("#sync_path_enabled").prop("checked", true);
@@ -248,6 +266,7 @@
         $("#sync_path_from").val(sync_item.from);
         $("#sync_path_to").val(sync_item.to);
         $("#sync_path_unknown").val(sync_item.unknown);
+        $("#sync_path_tmdbid").val(sync_item.tmdbid);
         $("#sync_path_syncmod").val(sync_item.syncmod);
         $("#sync_path_compatibility").prop("checked", sync_item.compatibility);
         $("#sync_path_rename").prop("checked", sync_item.rename);


### PR DESCRIPTION
我使用nastools有个场景是用rclone挂载网盘，但是网盘找到的资源多是没有名字，只有集数的，而且没法自动订阅，这样每次都要手动填tmdb，并且触发同步。

这个feature增加同步目录设置时预填写TMDB ID，因此对对应目录同步时，会直接使用TMDB ID，这样即便只有集数也能正常同步入库。

经过我自己测试可以正常使用，不过由于修改了sync_config，增加了TMDBID字段，更新这个版本时需要手动将user.db中CONFIG_SYNC_PATHS table新增TMDBID字段，否则无法正常启动。 命令如下：
```shell
sqlite3 user.db
alter table CONFIG_SYNC_PATHS add column TMDBID TEXT
```
请酌情考虑合入:)